### PR TITLE
Révision fonction chekMember

### DIFF
--- a/repository/RepositoryConnect.php
+++ b/repository/RepositoryConnect.php
@@ -20,6 +20,8 @@ class RepositoryConnect extends Database
     // cf.Database.php -> PDO::FETCH_ASSOC: retourne un tableau indexé par le nom de la colonne comme retourné dans le jeu de résultats
 
     // VÉRIFICATION DU MEMBRE LORS DE LA CONNEXION ET LANCEMENTS CONSÉCUTIFS DE SESSIONS DANS LE CONTROLLER
+
+    // Révision de cette fonction pour simplifier l'ouverture de SESSION dans le controllerBackmember (24 janvier)
     public function checkMember($member, $member_password)
     {        
 


### PR DESCRIPTION
Au lieu d'utiliser une fonction séparée pour stocker l'ID du membre en $_SESSION, la fonction checkMember() du repositoryConnect.php a été revue. $_SESSION['member_id'] stocke désormais l'ID du manager qui vient de se connecter.